### PR TITLE
make newOrderCommand accept item_id as item identifier instead of slug

### DIFF
--- a/unafamilia/src/main/java/com/unfamilia/application/order/OrderController.java
+++ b/unafamilia/src/main/java/com/unfamilia/application/order/OrderController.java
@@ -58,7 +58,7 @@ public class OrderController {
                         player.getDiscordUserId(),
                         orderId,
                         orderPayload.getItems().stream()
-                                .map(item -> new NewOrderCommand.OrderedItem(item.itemName(), item.quantity()))
+                                .map(item -> new NewOrderCommand.OrderedItem(item.item_id(), item.quantity()))
                                 .collect(Collectors.toList())
                 )
             )

--- a/unafamilia/src/main/java/com/unfamilia/application/order/OrderController.java
+++ b/unafamilia/src/main/java/com/unfamilia/application/order/OrderController.java
@@ -83,7 +83,7 @@ public class OrderController {
         @Data
         @NoArgsConstructor
         public static class OrderedItem {
-            private String name;
+            private Long itemId;
             private Integer quantity;
         }
     }

--- a/unafamilia/src/main/java/com/unfamilia/eggbot/domain/raidpackage/Item.java
+++ b/unafamilia/src/main/java/com/unfamilia/eggbot/domain/raidpackage/Item.java
@@ -15,6 +15,7 @@ import javax.persistence.*;
 @NoArgsConstructor
 @EqualsAndHashCode(callSuper = false)
 @Table(name = "item", indexes = {
+        @Index(name = "item_id", columnList = "item_id"),
         @Index(name = "slug", columnList = "slug")
 })
 public class Item extends PanacheEntityBase {
@@ -49,5 +50,9 @@ public class Item extends PanacheEntityBase {
 
     public static Item findByName(String slug) {
         return find("slug", slug).firstResult();
+    }
+
+    public static Item findById(Long id) {
+        return find("item_id", id);
     }
 }

--- a/unafamilia/src/main/java/com/unfamilia/eggbot/domain/raidpackage/Item.java
+++ b/unafamilia/src/main/java/com/unfamilia/eggbot/domain/raidpackage/Item.java
@@ -15,7 +15,6 @@ import javax.persistence.*;
 @NoArgsConstructor
 @EqualsAndHashCode(callSuper = false)
 @Table(name = "item", indexes = {
-        @Index(name = "item_id", columnList = "item_id"),
         @Index(name = "slug", columnList = "slug")
 })
 public class Item extends PanacheEntityBase {
@@ -50,9 +49,5 @@ public class Item extends PanacheEntityBase {
 
     public static Item findByName(String slug) {
         return find("slug", slug).firstResult();
-    }
-
-    public static Item findById(Long id) {
-        return find("item_id", id);
     }
 }

--- a/unafamilia/src/main/java/com/unfamilia/eggbot/domain/raidpackage/command/NewOrderCommand.java
+++ b/unafamilia/src/main/java/com/unfamilia/eggbot/domain/raidpackage/command/NewOrderCommand.java
@@ -7,6 +7,6 @@ import java.util.UUID;
 
 public record NewOrderCommand(Long orderMessageId, Long orderingUserId, UUID orderId,
                               List<OrderedItem> orderedItems) implements Command {
-    public record OrderedItem(String itemName, Integer quantity) {
+    public record OrderedItem(Long itemId, Integer quantity) {
     }
 }


### PR DESCRIPTION
python bot will send item_id as the identifier of an item for a new order. This change adjusts the Java side to accept an item_id instead of a slug